### PR TITLE
remove posix property for constructing uri path

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const getRequestParams = (method, region, payload, keys={}) => {
 		aws4.sign(opts)
 
 	return {
-		uri: 'https://' + path.posix.join(opts.hostname, opts.path),
+		uri: 'https://' + path.join(opts.hostname, opts.path),
 		headers: opts.headers
 	}
 }


### PR DESCRIPTION
thanks for this lib. after installing today in a React app (16.4) was getting a crash trying to log a message. issue was occurring because the "posix" property was undefined. i removed that prop and all works fine / logs showing up in Cloudwatch.