### PR TITLE
updates axios to remediate vulnerability CVE-2019-10742

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/nicolasdao/aws-cloudwatch-logger#readme",
   "dependencies": {
     "aws4": "^1.6.0",
-    "axios": "^0.17.1"
+    "axios": "^0.19.0"
   },
   "devDependencies": {
     "eslint": "^4.13.1",


### PR DESCRIPTION
I've been seeing a security notification for months in github that the axios version included here is a high severity issue. See: https://nvd.nist.gov/vuln/detail/CVE-2019-10742

Being that in our setup this is used server-side and has a very very low chance of being exploited except by accident, I ignored it. Today I grew tired of seeing the message so I made this change. It continues to work in our environment. Since there hasn't been a release in a long time, I pointed our project which includes this to point at our github fork. If there is a new release, we will point back and delete our fork.

Happy new year.