### PR TITLE
Fix error: Cannot read property 'data' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ const addLogsToStream = (entry, logGroupName, logStreamName, region, keys={}, se
 		})
 		.catch(err => {
 			//console.log('Oops')
-			const token = err.response.data.expectedSequenceToken
+			const token = err.response && err.response.data && err.response.data.expectedSequenceToken
 			if (token) {
 				_sequenceTokens.set(tokenKey, token)
 				retryCount += 1


### PR DESCRIPTION
Hi! We recently implement this module in one of our apps, and sometimes when there are an error sending the log to cloudwatch, the module fails with a `Cannot read property 'data' of undefined` reading the expectedSequenceToken. New version is appreciatted!