### PR TITLE
chore: bump axios version to remediate vulnerability CVE-2022-0155

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/nicolasdao/aws-cloudwatch-logger#readme",
   "dependencies": {
     "aws4": "^1.6.0",
-    "axios": "^0.19.0"
+    "axios": "^0.25.0"
   },
   "devDependencies": {
     "eslint": "^4.13.1",


### PR DESCRIPTION
Bump axios to eliminate the security [vulnerability](https://github.com/advisories/GHSA-74fj-2j2h-c42q) caused by follow-redirects.

Issue link : https://github.com/axios/axios/pull/4379
Release: https://github.com/axios/axios/releases/tag/v0.25.0